### PR TITLE
feat: Add configuration options for enabling/disabling certain configs

### DIFF
--- a/src/configs/gitignore.ts
+++ b/src/configs/gitignore.ts
@@ -1,0 +1,7 @@
+import gitignore from 'eslint-config-flat-gitignore';
+
+import type { Config } from '../types/index.js';
+
+const config: Config[] = [gitignore()];
+
+export default config;

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -2,33 +2,52 @@ import type { Config } from './types/index.js';
 
 import { getDependencies, hasDependency } from './utils/dependencies.js';
 
-export default async function configure(): Promise<Config[]> {
+interface Options {
+  gitignore?: boolean;
+  prettier?: boolean;
+  typescript?: boolean;
+}
+
+export default async function configure(
+  options: Options = {},
+): Promise<Config[]> {
   const dependencies = getDependencies();
 
-  return [
-    (await import('eslint-config-flat-gitignore')).default(),
+  const {
+    gitignore: enableGitignore = true,
+    prettier: enablePrettier = hasDependency(dependencies, 'prettier'),
+    typescript: enableTypescript = hasDependency(dependencies, 'typescript'),
+  } = options;
+
+  const configs: Config[] = [];
+
+  if (enableGitignore) {
+    configs.push(...(await import('./configs/gitignore.js')).default);
+  }
+
+  configs.push(
     {
       linterOptions: {
         reportUnusedDisableDirectives: true,
       },
     },
-    ...(await import('./configs/comments.js')).default,
-
     ...(await import('./configs/javascript.js')).default,
-
-    ...(hasDependency(dependencies, 'typescript') ?
-      (await import('./configs/typescript.js')).default
-    : []),
-
+    ...(await import('./configs/comments.js')).default,
     ...(await import('./configs/imports.js')).default,
-    ...(hasDependency(dependencies, 'typescript') ?
-      (await import('./configs/imports.js')).typescriptConfig
-    : []),
 
     ...(await import('./configs/perfectionist.js')).default,
+  );
 
-    ...(hasDependency(dependencies, 'prettier') ?
-      (await import('./configs/prettier.js')).default
-    : []),
-  ];
+  if (enableTypescript) {
+    configs.push(
+      ...(await import('./configs/typescript.js')).default,
+      ...(await import('./configs/imports.js')).typescriptConfig,
+    );
+  }
+
+  if (enablePrettier) {
+    configs.push(...(await import('./configs/prettier.js')).default);
+  }
+
+  return configs;
 }


### PR DESCRIPTION
Adds the feature to enable or disable specific configurations. The options include:

- `gitignore` option to explicitly enable/disable using `.gitignore` files to determine files to be ignored when linting. Defaults to `true`.
- `prettier` option to explicitly enable/disable the Prettier configuration. Defaults to `true` if `prettier` is installed locally, otherwise `false`.
- `typescript` option to enable/disable the TypeScript configurations. Defaults to `true` if `typescript` is installed locally, otherwise `false`.
