### PR TITLE
chore(deps-peer): Fix version range for peer dependency on eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "node": ">=22.11.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.21.0"
+        "eslint": "^9.5.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "eslint": ">=8.21.0"
+    "eslint": "^9.5.0"
   },
   "engines": {
     "node": ">=22.11.0"


### PR DESCRIPTION
BREAKING CHANGE: Now requires ESLint 9.5.0 or higher.
